### PR TITLE
RNG: Update kicad files to reflect 8-pin connections instead of 6-pin.

### DIFF
--- a/modules/RNG/PCBs/rng_pcb_front/rng_pcb_front.kicad_pcb
+++ b/modules/RNG/PCBs/rng_pcb_front/rng_pcb_front.kicad_pcb
@@ -10214,7 +10214,7 @@
 				(justify mirror)
 			)
 		)
-		(property "Value" "Conn_01x06_Pin"
+		(property "Value" "Conn_01x08_Pin"
 			(at 0 -20.11 0)
 			(layer "B.Fab")
 			(uuid "cf9f990d-49a5-4f72-a2ca-d99d2bd9f337")

--- a/modules/RNG/PCBs/rng_pcb_front/rng_pcb_front.kicad_sch
+++ b/modules/RNG/PCBs/rng_pcb_front/rng_pcb_front.kicad_sch
@@ -6720,7 +6720,7 @@
 				(justify right)
 			)
 		)
-		(property "Value" "Conn_01x06_Pin"
+		(property "Value" "Conn_01x08_Pin"
 			(at 78.74 163.195 0)
 			(effects
 				(font


### PR DESCRIPTION
Noticed that in the schematic and the interactive BOM that there is mention of a 6-pin header where it should be 8-pin. The actual BOM md file looked right. Maybe an artifact of an older design? Anyway, I corrected them, let me know what you think!